### PR TITLE
dev/kipp: Quote "off" for proxy request buffering

### DIFF
--- a/manifests/dev/kipp/ingress.yaml
+++ b/manifests/dev/kipp/ingress.yaml
@@ -2,15 +2,13 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: kipp-ingress
+  name: kipp
   namespace: dev
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
-    nginx.ingress.kubernetes.io/proxy-request-buffering: off
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;


### PR DESCRIPTION
YAML parses "on", "off", "yes", "no", "y", "n", "true" and "false" as boolean values. Therefore "off" needs to be quoted to parse the value correctly.